### PR TITLE
Add fade-in and playback position randomisation.

### DIFF
--- a/AshoutlookanFarewell/AshoutlookanFarewell.csproj
+++ b/AshoutlookanFarewell/AshoutlookanFarewell.csproj
@@ -219,6 +219,7 @@
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="RandomExtensions.cs" />
     <Compile Include="Settings.cs" />
     <Compile Include="SettingsForm.cs">
       <SubType>Form</SubType>

--- a/AshoutlookanFarewell/Properties/AssemblyInfo.cs
+++ b/AshoutlookanFarewell/Properties/AssemblyInfo.cs
@@ -7,11 +7,11 @@ using System.Security;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("AshoutlookanFarewell")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("A very silly Outlook plugin to add a bit of battlefield whimsy to your lives.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("AshoutlookanFarewell")]
-[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyCopyright("Copyright © Chris Platts 2021")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/AshoutlookanFarewell/RandomExtensions.cs
+++ b/AshoutlookanFarewell/RandomExtensions.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AshoutlookanFarewell
+{
+    /// <summary>
+    /// Extension method to generate 64-bit random integers, needed for random playback positions.
+    /// Taken from: https://stackoverflow.com/a/6651656/14104177
+    /// Massive overkill - covers modulo bias, etc.  But correct is correct, after all.
+    /// </summary>
+    static class RandomExtensions
+    {
+        public static long NextLong(this Random rnd)
+        {
+            byte[] buffer = new byte[8];
+            rnd.NextBytes(buffer);
+            return BitConverter.ToInt64(buffer, 0);
+        }
+
+        public static long NextLong(this Random rnd, long min, long max)
+        {
+            EnsureMinLEQMax(ref min, ref max);
+            long numbersInRange = unchecked(max - min + 1);
+            if (numbersInRange < 0)
+                throw new ArgumentException("Size of range between min and max must be less than or equal to Int64.MaxValue");
+
+            long randomOffset = NextLong(rnd);
+            if (IsModuloBiased(randomOffset, numbersInRange))
+                return NextLong(rnd, min, max); // Try again
+            else
+                return min + PositiveModuloOrZero(randomOffset, numbersInRange);
+        }
+        static bool IsModuloBiased(long randomOffset, long numbersInRange)
+        {
+            long greatestCompleteRange = numbersInRange * (long.MaxValue / numbersInRange);
+            return randomOffset > greatestCompleteRange;
+        }
+
+        static long PositiveModuloOrZero(long dividend, long divisor)
+        {
+            long mod;
+            Math.DivRem(dividend, divisor, out mod);
+            if (mod < 0)
+                mod += divisor;
+            return mod;
+        }
+
+        static void EnsureMinLEQMax(ref long min, ref long max)
+        {
+            if (min <= max)
+                return;
+            long temp = min;
+            min = max;
+            max = temp;
+        }
+    }
+
+}

--- a/AshoutlookanFarewell/Settings.cs
+++ b/AshoutlookanFarewell/Settings.cs
@@ -24,6 +24,7 @@ namespace AshoutlookanFarewell
         public static List<string> NomsDePlume = new List<string>();
         public static string MissiveFontFace = "";
         public static bool RandomisePlayhead = true;
+        public static bool FadeIn = true;
 
         static Random rnd = new Random();
 


### PR DESCRIPTION
- Update AssemblyInfo.
- Adds support for fading in playback (closes #10)
- Adds support for randomising the playhead before starting playback. (closes #9)
- Adds extension to Random() to support generation of random 64-bit integers (needed for #9)

The fade-in/out code might need revisiting. It blocks the UI until the fade is done, which might annoy users.